### PR TITLE
Fix NPE when not configuring using SNI

### DIFF
--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/AbstractRunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/AbstractRunMojo.java
@@ -1238,7 +1238,7 @@ public abstract class AbstractRunMojo
                     httpsConnector.setSecure( true );
                     httpsConnector.setProperty( "SSLEnabled", "true" );
 
-                    if (sslHostConfigs.size() > 0) {
+                    if (sslHostConfigs != null && sslHostConfigs.size() > 0) {
                         for (HostConfig sslHostConfig : sslHostConfigs) {
                             SSLHostConfig newHostConfig = new SSLHostConfig();
                             newHostConfig.setHostName(sslHostConfig.getHostname());


### PR DESCRIPTION
Forgot to make sure non-SNI based configuration was still working. Unfortunately with how this plugin is written I'm not sure how to put a test in for this.