### PR TITLE
Fix Jar pathing issue

### DIFF
--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/RunMojo.java
@@ -689,7 +689,7 @@ public class RunMojo
                 File file = new File( uri );
                 if ( !file.isDirectory() )
                 {
-                    jarPaths.add( file.getAbsolutePath() );
+                    jarPaths.add( uri.getPath() );
                 }
             }
         }


### PR DESCRIPTION
There was an issue where the discovered jar paths were being registered
using platform specific pathing rather than using URI based pathing.
This causes JSP -> Java conversion to have strings with incorrect
'escape characters'.