### PR TITLE
FS-29542 support infusionsoft-core upgrade to spring_5_2_3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <!-- server port for it tests -->
     <its.server.port>2008</its.server.port>
     <tomcat8Version>8.5.24</tomcat8Version>
-
+    <tomcatDbcpVersion>8.5.53</tomcatDbcpVersion>
     <!-- to prevent isssues with last apache parent pom -->
     <arguments />
 
@@ -360,7 +360,7 @@
       <dependency>
         <groupId>org.apache.tomcat</groupId>
         <artifactId>tomcat-dbcp</artifactId>
-        <version>${tomcat8Version}</version>
+        <version>${tomcatDbcpVersion}</version>
       </dependency>
 
       <dependency>

--- a/tomcat8-maven-plugin/pom.xml
+++ b/tomcat8-maven-plugin/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-dbcp</artifactId>
-      <version>${tomcat8Version}</version>
+      <version>${tomcatDbcpVersion}</version>
     </dependency>
 
     <dependency>

--- a/tomcat8-maven-plugin/src/site/apt/adjust-embedded-tomcat-version.apt.vm
+++ b/tomcat8-maven-plugin/src/site/apt/adjust-embedded-tomcat-version.apt.vm
@@ -77,7 +77,7 @@ Adjust Tomcat Version
           <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-dbcp</artifactId>
-            <version>${tomcat.version}</version>
+            <version>8.5.53</version>
           </dependency>
 
           <dependency>

--- a/tomcat8-war-runner/pom.xml
+++ b/tomcat8-war-runner/pom.xml
@@ -71,7 +71,7 @@
     <dependency>
       <groupId>org.apache.tomcat</groupId>
       <artifactId>tomcat-dbcp</artifactId>
-	  <version>${tomcat8Version}</version>
+	  <version>${tomcatDbcpVersion}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This is a quick change to support the spring 5.2.3 upgrade.  Without this change the existing dbcp jar prevents infusionsoft-core from starting up properly via the tomcat-maven-plugin.