### PR TITLE
PDS-432: Bumping tomcat version to 8.5.69

### DIFF
--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -74,6 +74,7 @@
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-core</artifactId>
+      <version>${tomcat8Version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -68,10 +68,12 @@
     <its.https.port>2003</its.https.port>
     <!-- ajp port used to run it test -->
     <its.ajp.port>2001</its.ajp.port>
+    <!-- ajp protocol secret for it tests -->
+    <its.ajp.secret>myajpsecret</its.ajp.secret>
     <!-- server port for it tests -->
     <its.server.port>2008</its.server.port>
-    <tomcat8Version>8.5.24</tomcat8Version>
-    <tomcatDbcpVersion>8.5.53</tomcatDbcpVersion>
+    <tomcat8Version>8.5.69</tomcat8Version>
+    <tomcatDbcpVersion>8.5.69</tomcatDbcpVersion>
     <!-- to prevent isssues with last apache parent pom -->
     <arguments />
 

--- a/tomcat8-maven-plugin/pom.xml
+++ b/tomcat8-maven-plugin/pom.xml
@@ -342,6 +342,7 @@
                     <its.http.port>${its.http.port}</its.http.port>
                     <its.https.port>${its.https.port}</its.https.port>
                     <its.ajp.port>${its.ajp.port}</its.ajp.port>
+                    <its.ajp.secret>${its.ajp.secret}</its.ajp.secret>
                     <java.io.tmpdir>${project.build.directory}</java.io.tmpdir>
                   </systemPropertyVariables>
                   <redirectTestOutputToFile>false</redirectTestOutputToFile>

--- a/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/AbstractRunMojo.java
+++ b/tomcat8-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat8/run/AbstractRunMojo.java
@@ -37,6 +37,7 @@ import org.apache.catalina.webresources.FileResource;
 import org.apache.catalina.webresources.StandardRoot;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.coyote.ajp.AjpNioProtocol;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.factory.ArtifactFactory;
 import org.apache.maven.artifact.repository.ArtifactRepository;
@@ -1310,6 +1311,12 @@ public abstract class AbstractRunMojo
                     ajpConnector.setPort( ajpPort );
                     ajpConnector.setURIEncoding( uriEncoding );
                     ajpConnector.setUseBodyEncodingForURI( this.useBodyEncodingForURI );
+
+                    ajpConnector.setSecure( true );
+                    AjpNioProtocol protocol= (AjpNioProtocol)ajpConnector.getProtocolHandler();
+                    protocol.setSecret("myapjsecret");
+                    protocol.setSecretRequired(true);
+
                     if ( address != null )
                     {
                         ajpConnector.setAttribute( "address", address );

--- a/tomcat8-maven-plugin/src/site/apt/adjust-embedded-tomcat-version.apt.vm
+++ b/tomcat8-maven-plugin/src/site/apt/adjust-embedded-tomcat-version.apt.vm
@@ -35,7 +35,7 @@ Adjust Tomcat Version
 <project>
    [...]
   <properties>
-   <tomcat.version>7.0.50</tomcat.version>
+   <tomcat.version>8.5.69</tomcat.version>
    [...]
   </properties>
    [...]

--- a/tomcat8-maven-plugin/src/test/java/org/apache/tomcat/maven/it/Tomcat8RunMultiConfigIT.java
+++ b/tomcat8-maven-plugin/src/test/java/org/apache/tomcat/maven/it/Tomcat8RunMultiConfigIT.java
@@ -32,6 +32,6 @@ public class Tomcat8RunMultiConfigIT
     {
         verifier.verifyTextInLog("INFO: Starting ProtocolHandler [\"http-nio-" + getHttpItPort() + "\"]");
         verifier.verifyTextInLog("INFO: Starting ProtocolHandler [\"https-jsse-nio-" + getHttpsItPort() + "\"]");
-        verifier.verifyTextInLog("INFO: Starting ProtocolHandler [\"ajp-nio-" + getAjpItPort() + "\"]");
+        verifier.verifyTextInLog( "INFO: Starting ProtocolHandler [\"ajp-nio-127.0.0.1-"+ getAjpItPort() +"\"]" );
     }
 }

--- a/tomcat8-maven-plugin/src/test/java/org/apache/tomcat/maven/it/Tomcat8SimpleWarProjectIT.java
+++ b/tomcat8-maven-plugin/src/test/java/org/apache/tomcat/maven/it/Tomcat8SimpleWarProjectIT.java
@@ -37,6 +37,6 @@ public class Tomcat8SimpleWarProjectIT
     {
         verifier.verifyTextInLog("INFO: Starting ProtocolHandler [\"http-nio-" + getHttpItPort() + "\"]");
 
-        verifier.verifyTextInLog( "INFO: Starting ProtocolHandler [\"ajp-nio-"+ getAjpItPort() +"\"]" );
+        verifier.verifyTextInLog( "INFO: Starting ProtocolHandler [\"ajp-nio-127.0.0.1-"+ getAjpItPort() +"\"]" );
     }
 }

--- a/tomcat8-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat8Runner.java
+++ b/tomcat8-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat8Runner.java
@@ -26,6 +26,8 @@ import org.apache.catalina.startup.Catalina;
 import org.apache.catalina.startup.ContextConfig;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.catalina.valves.AccessLogValve;
+import org.apache.coyote.ajp.AbstractAjpProtocol;
+import org.apache.coyote.ajp.AjpNioProtocol;
 import org.apache.juli.ClassLoaderLogManager;
 import org.apache.tomcat.util.ExceptionUtils;
 import org.apache.tomcat.util.http.fileupload.FileUtils;
@@ -82,7 +84,6 @@ public class Tomcat8Runner
      */
     public static final String HTTP_PORT_KEY = "httpPort";
 
-
     public int httpPort;
 
     public int httpsPort;
@@ -90,6 +91,8 @@ public class Tomcat8Runner
     public int maxPostSize = 2097152;
 
     public int ajpPort;
+
+    public String ajpSecret;
 
     public String serverXmlPath;
 
@@ -372,6 +375,10 @@ public class Tomcat8Runner
                 Connector ajpConnector = new Connector( "org.apache.coyote.ajp.AjpProtocol" );
                 ajpConnector.setPort( ajpPort );
                 ajpConnector.setURIEncoding( uriEncoding );
+                ajpConnector.setSecure( true );
+                AjpNioProtocol protocol= (AjpNioProtocol)ajpConnector.getProtocolHandler();
+                protocol.setSecret( ajpSecret );
+                protocol.setSecretRequired(true);
                 tomcat.getService().addConnector( ajpConnector );
             }
 

--- a/tomcat8-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat8RunnerCli.java
+++ b/tomcat8-war-runner/src/main/java/org/apache/tomcat/maven/runner/Tomcat8RunnerCli.java
@@ -55,6 +55,9 @@ public class Tomcat8RunnerCli
     static Option ajpPort =
         OptionBuilder.withArgName( "ajpPort" ).hasArg().withDescription( "ajp port to use" ).create( "ajpPort" );
 
+    static Option ajpSecret =
+        OptionBuilder.withArgName("ajpSecret").hasArg().withDescription("ajp secret to use").create("ajpSecret");
+
     static Option serverXmlPath =
         OptionBuilder.withArgName( "serverXmlPath" ).hasArg().withDescription( "server.xml to use, optional" ).create(
             "serverXmlPath" );
@@ -101,6 +104,7 @@ public class Tomcat8RunnerCli
         options.addOption( httpPort ) //
             .addOption( httpsPort ) //
             .addOption( ajpPort ) //
+            .addOption(ajpSecret) //
             .addOption( serverXmlPath ) //
             .addOption( resetExtract ) //
             .addOption( help ) //
@@ -179,6 +183,10 @@ public class Tomcat8RunnerCli
         if ( line.hasOption( ajpPort.getOpt() ) )
         {
             tomcat8Runner.ajpPort = Integer.parseInt( line.getOptionValue( ajpPort.getOpt() ) );
+        }
+        if ( line.hasOption( ajpSecret.getOpt() ))
+        {
+            tomcat8Runner.ajpSecret = line.getOptionValue( ajpSecret.getOpt() );
         }
         if ( line.hasOption( resetExtract.getOpt() ) )
         {


### PR DESCRIPTION
- Attempted to bump to tomcat 8.5.68, but that resulted in errors when running core / Max Classic (issue with compilation of JSPs including tags - described here https://bz.apache.org/bugzilla/show_bug.cgi?id=65390 , and as noted in a comment on that thread, "Fixed in: 8.5.x for 8.5.69 onwards )
- Bumped tomcat version in pom.xml
- Added property its.ajp.secret to pom.xml, created corresponding option in Tomcat8RunnerCli
- Setting secret in AbstractRunMojo and Tomcat8Runner
- Modified assertions in Tomcat8RunMultiConfigIT and Tomcat8SimpleWarProjectIT