### PR TITLE
PDS-4617 upgrade plexus archiver

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -563,7 +563,7 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
-        <version>2.1.1</version>
+        <version>4.8.0</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>


### PR DESCRIPTION
[PDS-4617](https://keap.atlassian.net/browse/PDS-4617)

Upgraded org.codehaus.plexus:plexus-archiver for security reasons.

[PDS-4617]: https://keap.atlassian.net/browse/PDS-4617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ