### PR TITLE
Replace Log4j with Slf4j

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,3 @@
-build_image: &build_image
-  circleci/openjdk:8u171-jdk-node-browsers
-
 test_results_dir: &test_results_dir
   /tmp/circleci-test-results
 
@@ -9,7 +6,7 @@ artifacts_dir: &artifacts_dir
 
 build_container: &build_container
   docker:
-    - image: *build_image
+    - image: cimg/openjdk:17.0
   environment:
     CIRCLE_TEST_REPORTS: *test_results_dir
     CIRCLE_ARTIFACTS: *artifacts_dir

--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -110,6 +110,12 @@
       <artifactId>commons-lang</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.infusionsoft</groupId>
+      <artifactId>logging</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/common-tomcat-maven-plugin/pom.xml
+++ b/common-tomcat-maven-plugin/pom.xml
@@ -116,6 +116,12 @@
       <scope>runtime</scope>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/common-tomcat-maven-plugin/src/test/java/org/apache/tomcat/maven/common/TomcatManagerTest.java
+++ b/common-tomcat-maven-plugin/src/test/java/org/apache/tomcat/maven/common/TomcatManagerTest.java
@@ -18,7 +18,9 @@ package org.apache.tomcat.maven.common;
  * under the License.
  */
 
-import junit.framework.TestCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.catalina.Context;
 import org.apache.catalina.startup.Tomcat;
 import org.apache.commons.io.IOUtils;
@@ -37,13 +39,14 @@ import java.io.StringWriter;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * @author Olivier Lamy
  */
-public class TomcatManagerTest
-    extends TestCase
-{
+public class TomcatManagerTest {
 
     Tomcat tomcat;
 
@@ -62,11 +65,10 @@ public class TomcatManagerTest
         return System.getProperty( "basedir" );
     }
 
-    @Override
-    protected void setUp()
+    @Before
+    public void setUp()
         throws Exception
     {
-        super.setUp();
         tomcat = new Tomcat();
         tomcat.setBaseDir( System.getProperty( "java.io.tmpdir" ) );
         tomcat.setPort( 0 );
@@ -95,15 +97,15 @@ public class TomcatManagerTest
         System.out.println( "redirect Tomcat started on port:" + redirectPort );
     }
 
-    @Override
-    protected void tearDown()
+    @After
+    public void tearDown()
         throws Exception
     {
-        super.tearDown();
         tomcat.stop();
     }
 
 
+    @Test
     public void testDeployWar()
         throws Exception
     {
@@ -129,6 +131,7 @@ public class TomcatManagerTest
         }
     }
 
+    @Test
     public void testDeployWarWithRedirect()
         throws Exception
     {
@@ -160,6 +163,7 @@ public class TomcatManagerTest
         }
     }
 
+    @Test
     public void testDeployWarWithRedirectRelative()
         throws Exception
     {

--- a/pom.xml
+++ b/pom.xml
@@ -517,11 +517,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>*</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -564,6 +560,12 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-archiver</artifactId>
         <version>4.8.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.slf4j</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -609,12 +611,36 @@
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-classworlds</artifactId>
-        <version>2.2.2</version>
+        <version>2.8.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>10.0.1</version>
+        <version>20.0</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>1.3.15</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-bom</artifactId>
+        <version>2.0.17</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.infusionsoft</groupId>
+        <artifactId>logging</artifactId>
+        <version>4.0.10</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.springframework</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+        <scope>runtime</scope>
       </dependency>
 
       <!-- Test Dependencies -->
@@ -638,26 +664,13 @@
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
         <version>4.3.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
-        <version>1.7.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>1.7.5</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>2.17.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>2.0.1</version>
+        <exclusions>
+          <exclusion>
+            <!-- replaced with jcl-over-slf4j: -->
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -683,7 +696,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>3.8.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
     <surefire.version>2.18.1</surefire.version>
     <failsafe.version>${surefire.version}</failsafe.version>
 
-    <junit.version>4.10</junit.version>
+    <junit.version>4.13.2</junit.version>
     <it.sleep.time>2000</it.sleep.time>
     <verifier.maven.debug>false</verifier.maven.debug>
     <verifier.debugJvm>false</verifier.debugJvm>

--- a/tomcat-maven-plugin-it/pom.xml
+++ b/tomcat-maven-plugin-it/pom.xml
@@ -59,6 +59,11 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.infusionsoft</groupId>
+      <artifactId>logging</artifactId>
+      <scope>runtime</scope>
+    </dependency>
 
   </dependencies>
 

--- a/tomcat9-maven-plugin/pom.xml
+++ b/tomcat9-maven-plugin/pom.xml
@@ -216,18 +216,24 @@
     </dependency>
 
     <dependency>
+      <!-- SLF4J bridge for 3rd party libraries built using java util logging -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>jul-to-slf4j</artifactId>
+    </dependency>
+    <dependency>
+      <!-- SLF4J bridge for 3rd party libraries built using Jakarta commons logging -->
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
+      <!-- SLF4J bridge for 3rd party libraries built using Log4J v1 -->
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>test</scope>
+      <!-- includes the configurator that pulls it all together -->
+      <groupId>com.infusionsoft</groupId>
+      <artifactId>logging</artifactId>
     </dependency>
   </dependencies>
 

--- a/tomcat9-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat9/run/RunMojo.java
+++ b/tomcat9-maven-plugin/src/main/java/org/apache/tomcat/maven/plugin/tomcat9/run/RunMojo.java
@@ -485,6 +485,9 @@ public class RunMojo
                                 jarFile = new JarFile( file );
 
                                 JarEntry jarEntry = jarFile.getJarEntry( StringUtils.removeStart( path, "/" ) );
+                                if (jarEntry == null) {
+                                    return new EmptyResource(this, webAppPath, new File(url.getFile()));
+                                }
                                 JarResourceSet jarResourceSet = new JarResourceSet(this, getPath(), jarOnlyUri.getPath(), "/WEB-INF/lib");
                                 return new JarResource(jarResourceSet, getPath(), jarOnlyUri.toString(), jarEntry);
                             }


### PR DESCRIPTION
1. Replace Log4j/JUL with SLF4J
2. Fix a NPE when tomcat9:run runs with delegate=false on the classloader
3. Update JUnit version

Pulls in com.infusionsoft:logging to take advantage of the configurator and the dependencies.